### PR TITLE
Debsync20191206 add modules

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -33,7 +33,8 @@ Build-Depends: debhelper (>= 10~),
                libmaxminddb-dev,
                libcurl4-openssl-dev,
                libsnappy-dev,
-               libsnmp-dev
+               libsnmp-dev,
+               librdkafka-dev (>=1.0.0)
 Build-Conflicts: autoconf2.13
 Standards-Version: 4.4.1
 Homepage: https://www.syslog-ng.com/
@@ -578,6 +579,29 @@ Description: Enhanced system logging daemon (HTTP destination)
  .
  This package provides an HTTP destination, allowing one to send syslog messages as HTTP
  PUT messages to an http server.
+
+Package: syslog-ng-mod-rdkafka
+Architecture: any
+Multi-Arch: foreign
+Depends: ${shlibs:Depends}, ${misc:Depends}, syslog-ng-core (>= ${source:Version}), syslog-ng-core (<< ${source:Version}.1~)
+Description: Enhanced system logging daemon (Kafka destination, based on librdkafka)
+ syslog-ng is an enhanced log daemon, supporting a wide range of input
+ and output methods: syslog, unstructured text, message queues,
+ databases (SQL and NoSQL alike) and more.
+ .
+ Key features:
+ .
+  * receive and send RFC3164 and RFC5424 style syslog messages
+  * work with any kind of unstructured data
+  * receive and send JSON formatted messages
+  * classify and structure logs with builtin parsers (csv-parser(),
+    db-parser(), etc.)
+  * normalize, crunch and process logs as they flow through the system
+  * hand on messages for further processing using message queues (like
+    AMQP), files or databases (like PostgreSQL or MongoDB).
+ .
+ This package provides a native Kafka destination, written entirely in the C programming
+ language, based on the librdkafka client library.
 
 Package: syslog-ng-mod-extra
 Architecture: all

--- a/debian/control
+++ b/debian/control
@@ -122,10 +122,10 @@ Multi-Arch: foreign
 Depends: ${shlibs:Depends}, ${misc:Depends}, util-linux (>= 2.12-10), lsb-base (>= 3.0-6)
 Recommends: logrotate
 Suggests: ${sng:CoreModules}, ${sng:Modules}
-Provides: system-log-daemon, linux-kernel-log-daemon, libsyslog-ng-dev, syslog-ng-mod-journal
+Provides: system-log-daemon, linux-kernel-log-daemon, libsyslog-ng-dev, syslog-ng-mod-journal, syslog-ng-mod-pacctformat
 Conflicts: system-log-daemon, linux-kernel-log-daemon
-Replaces: syslog-ng (<< 3.3.0~), libsyslog-ng-dev, syslog-ng-mod-json (<< 3.19.1~), syslog-ng-mod-journal (<< 3.25.1~)
-Breaks: syslog-ng (<< 3.3.0~), libsyslog-ng-dev, syslog-ng-mod-json (<< 3.19.1~), syslog-ng-mod-journal (<< 3.25.1~)
+Replaces: syslog-ng (<< 3.3.0~), libsyslog-ng-dev, syslog-ng-mod-json (<< 3.19.1~), syslog-ng-mod-journal (<< 3.25.1~), syslog-ng-mod-pacctformat (<< 3.25.1~)
+Breaks: syslog-ng (<< 3.3.0~), libsyslog-ng-dev, syslog-ng-mod-json (<< 3.19.1~), syslog-ng-mod-journal (<< 3.25.1~), syslog-ng-mod-pacctformat (<< 3.25.1~)
 Description: Enhanced system logging daemon (core)
  syslog-ng is an enhanced log daemon, supporting a wide range of input
  and output methods: syslog, unstructured text, message queues,
@@ -267,28 +267,6 @@ Description: Enhanced system logging daemon (GeoIP2 plugin)
  This package provides the GeoIP2 template function plugin, which
  allows one to do non-DNS IP-to-country resolving from syslog-ng
  templates. GeoIP2 uses MaxMind DB.
-
-Package: syslog-ng-mod-pacctformat
-Architecture: linux-any
-Multi-Arch: foreign
-Depends: ${shlibs:Depends}, ${misc:Depends}, syslog-ng-core (>= ${source:Version}), syslog-ng-core (<< ${source:Version}.1~)
-Description: Enhanced system logging daemon (getent)
- syslog-ng is an enhanced log daemon, supporting a wide range of input
- and output methods: syslog, unstructured text, message queues,
- databases (SQL and NoSQL alike) and more.
- .
- Key features:
- .
-  * receive and send RFC3164 and RFC5424 style syslog messages
-  * work with any kind of unstructured data
-  * receive and send JSON formatted messages
-  * classify and structure logs with builtin parsers (csv-parser(),
-    db-parser(), etc.)
-  * normalize, crunch and process logs as they flow through the system
-  * hand on messages for further processing using message queues (like
-    AMQP), files or databases (like PostgreSQL or MongoDB).
- .
- This package provides the pacctformat module for syslog-ng.
 
 Package: syslog-ng-mod-redis
 Architecture: any

--- a/debian/control
+++ b/debian/control
@@ -32,7 +32,8 @@ Build-Depends: debhelper (>= 10~),
                libxml2-utils, geoip-database,
                libmaxminddb-dev,
                libcurl4-openssl-dev,
-               libsnappy-dev
+               libsnappy-dev,
+               libsnmp-dev
 Build-Conflicts: autoconf2.13
 Standards-Version: 4.4.1
 Homepage: https://www.syslog-ng.com/
@@ -507,6 +508,29 @@ Description: Enhanced system logging daemon (map-value-pairs plugin)
  .
  With this package, it is possible to copy key-value pairs and do some other
  conversion and alteration in key-value pairs.
+
+Package: syslog-ng-mod-snmp
+Architecture: any
+Multi-Arch: foreign
+Depends: ${shlibs:Depends}, ${misc:Depends}, syslog-ng-core (>= ${source:Version}), syslog-ng-core (<< ${source:Version}.1~)
+Description: Enhanced system logging daemon (SNMP plugin)
+ syslog-ng is an enhanced log daemon, supporting a wide range of input
+ and output methods: syslog, unstructured text, message queues,
+ databases (SQL and NoSQL alike) and more.
+ .
+ Key features:
+ .
+  * receive and send RFC3164 and RFC5424 style syslog messages
+  * work with any kind of unstructured data
+  * receive and send JSON formatted messages
+  * classify and structure logs with builtin parsers (csv-parser(),
+    db-parser(), etc.)
+  * normalize, crunch and process logs as they flow through the system
+  * hand on messages for further processing using message queues (like
+    AMQP), files or databases (like PostgreSQL or MongoDB).
+ .
+ This package provides the SNMP destination plugin, which allows one
+ to send messages to an snmp server.
 
 Package: syslog-ng-mod-snmptrapd-parser
 Architecture: any

--- a/debian/control
+++ b/debian/control
@@ -578,6 +578,29 @@ Description: Enhanced system logging daemon (xml parser plugin)
  The xml parser can process input in xml format, and adds the parsed data
  to the message object.
 
+Package: syslog-ng-mod-http
+Architecture: any
+Multi-Arch: foreign
+Depends: ${shlibs:Depends}, ${misc:Depends}, syslog-ng-core (>= ${source:Version}), syslog-ng-core (<< ${source:Version}.1~)
+Description: Enhanced system logging daemon (HTTP destination)
+ syslog-ng is an enhanced log daemon, supporting a wide range of input
+ and output methods: syslog, unstructured text, message queues,
+ databases (SQL and NoSQL alike) and more.
+ .
+ Key features:
+ .
+  * receive and send RFC3164 and RFC5424 style syslog messages
+  * work with any kind of unstructured data
+  * receive and send JSON formatted messages
+  * classify and structure logs with builtin parsers (csv-parser(),
+    db-parser(), etc.)
+  * normalize, crunch and process logs as they flow through the system
+  * hand on messages for further processing using message queues (like
+    AMQP), files or databases (like PostgreSQL or MongoDB).
+ .
+ This package provides an HTTP destination, allowing one to send syslog messages as HTTP
+ PUT messages to an http server.
+
 Package: syslog-ng-mod-extra
 Architecture: all
 Multi-Arch: foreign

--- a/debian/control
+++ b/debian/control
@@ -122,10 +122,10 @@ Multi-Arch: foreign
 Depends: ${shlibs:Depends}, ${misc:Depends}, util-linux (>= 2.12-10), lsb-base (>= 3.0-6)
 Recommends: logrotate
 Suggests: ${sng:CoreModules}, ${sng:Modules}
-Provides: system-log-daemon, linux-kernel-log-daemon, libsyslog-ng-dev, syslog-ng-mod-journal, syslog-ng-mod-pacctformat
+Provides: system-log-daemon, linux-kernel-log-daemon, libsyslog-ng-dev, syslog-ng-mod-journal, syslog-ng-mod-pacctformat, syslog-ng-mod-tag-parser
 Conflicts: system-log-daemon, linux-kernel-log-daemon
-Replaces: syslog-ng (<< 3.3.0~), libsyslog-ng-dev, syslog-ng-mod-json (<< 3.19.1~), syslog-ng-mod-journal (<< 3.25.1~), syslog-ng-mod-pacctformat (<< 3.25.1~)
-Breaks: syslog-ng (<< 3.3.0~), libsyslog-ng-dev, syslog-ng-mod-json (<< 3.19.1~), syslog-ng-mod-journal (<< 3.25.1~), syslog-ng-mod-pacctformat (<< 3.25.1~)
+Replaces: syslog-ng (<< 3.3.0~), libsyslog-ng-dev, syslog-ng-mod-json (<< 3.19.1~), syslog-ng-mod-journal (<< 3.25.1~), syslog-ng-mod-pacctformat (<< 3.25.1~), syslog-ng-mod-tag-parser (<< 3.25.1~)
+Breaks: syslog-ng (<< 3.3.0~), libsyslog-ng-dev, syslog-ng-mod-json (<< 3.19.1~), syslog-ng-mod-journal (<< 3.25.1~), syslog-ng-mod-pacctformat (<< 3.25.1~), syslog-ng-mod-tag-parser (<< 3.25.1~)
 Description: Enhanced system logging daemon (core)
  syslog-ng is an enhanced log daemon, supporting a wide range of input
  and output methods: syslog, unstructured text, message queues,
@@ -609,29 +609,6 @@ Description: Enhanced system logging daemon (extra plugins)
   * Load balancer destination
   * osquery destination
   * ewmm (Enterprise wide messaging model) destination and parser
-
-Package: syslog-ng-mod-tag-parser
-Architecture: any
-Multi-Arch: foreign
-Depends: ${shlibs:Depends}, ${misc:Depends}, syslog-ng-core (>= ${source:Version}), syslog-ng-core (<< ${source:Version}.1~)
-Description: Enhanced system logging daemon (tag parser plugin)
- syslog-ng is an enhanced log daemon, supporting a wide range of input
- and output methods: syslog, unstructured text, message queues,
- databases (SQL and NoSQL alike) and more.
- .
- Key features:
- .
-  * receive and send RFC3164 and RFC5424 style syslog messages
-  * work with any kind of unstructured data
-  * receive and send JSON formatted messages
-  * classify and structure logs with builtin parsers (csv-parser(),
-    db-parser(), etc.)
-  * normalize, crunch and process logs as they flow through the system
-  * hand on messages for further processing using message queues (like
-    AMQP), files or databases (like PostgreSQL or MongoDB).
- .
- The new tags-parser() takes a value encoded by $TAGS and parses it
- back into actual tags on the message.
 
 Package: syslog-ng-mod-examples
 Architecture: any

--- a/debian/rules
+++ b/debian/rules
@@ -103,6 +103,7 @@ override_dh_auto_configure:
 		--enable-python \
 		--enable-snmp-dest \
 		--enable-http \
+		--enable-kafka=auto \
 		\
 		--with-python=3 \
 		--with-mongoc=system \

--- a/debian/rules
+++ b/debian/rules
@@ -102,6 +102,7 @@ override_dh_auto_configure:
 		$(PACCT_CONFIGURE_OPTS) \
 		--enable-python \
 		--enable-snmp-dest \
+		--enable-http \
 		\
 		--with-python=3 \
 		--with-mongoc=system \

--- a/debian/rules
+++ b/debian/rules
@@ -101,8 +101,9 @@ override_dh_auto_configure:
 		--enable-amqp \
 		$(PACCT_CONFIGURE_OPTS) \
 		--enable-python \
-		--with-python=3 \
+		--enable-snmp-dest \
 		\
+		--with-python=3 \
 		--with-mongoc=system \
 		--with-ivykis=system \
 		--with-jsonc=system \

--- a/debian/syslog-ng-core.install
+++ b/debian/syslog-ng-core.install
@@ -18,6 +18,7 @@ usr/lib/syslog-ng/*/libdbparser.so
 usr/lib/syslog-ng/*/libjson-plugin.so
 usr/lib/syslog-ng/*/libhook-commands.so
 usr/lib/syslog-ng/*/libkvformat.so
+usr/lib/syslog-ng/*/libtags-parser.so
 usr/lib/syslog-ng/*/liblinux-kmsg-format.so
 usr/lib/syslog-ng/*/libpseudofile.so
 usr/lib/syslog-ng/*/libsyslogformat.so

--- a/debian/syslog-ng-core.install
+++ b/debian/syslog-ng-core.install
@@ -50,6 +50,8 @@ usr/share/syslog-ng/include/scl/slack/*
 usr/share/syslog-ng/include/scl/telegram/*
 usr/share/syslog-ng/xsd/*
 [linux-any] usr/lib/syslog-ng/*/libsdjournal.so
+[linux-any] usr/lib/syslog-ng/*/libpacctformat.so
+
 #[!kfreebsd-any] lib/systemd/system/*
 [!kfreebsd-any] debian/syslog-ng.systemd =>  lib/systemd/system/syslog-ng.service
 

--- a/debian/syslog-ng-core.install
+++ b/debian/syslog-ng-core.install
@@ -6,7 +6,6 @@ usr/sbin/*
 usr/lib/syslog-ng/libsyslog-ng-*.so.*
 usr/lib/syslog-ng/libevtlog-*.so.*
 usr/lib/syslog-ng/libsecret-storage.so*
-usr/lib/syslog-ng/*/libhttp.so
 usr/lib/syslog-ng/*/libaffile.so
 usr/lib/syslog-ng/*/libafprog.so
 usr/lib/syslog-ng/*/libafsocket.so

--- a/debian/syslog-ng-mod-http.install
+++ b/debian/syslog-ng-mod-http.install
@@ -1,0 +1,1 @@
+usr/lib/syslog-ng/*/libhttp.so

--- a/debian/syslog-ng-mod-pacctformat.install
+++ b/debian/syslog-ng-mod-pacctformat.install
@@ -1,2 +1,0 @@
-usr/lib/syslog-ng/*/libpacctformat.so
-usr/share/syslog-ng/include/scl/pacct/*

--- a/debian/syslog-ng-mod-rdkafka.install
+++ b/debian/syslog-ng-mod-rdkafka.install
@@ -1,0 +1,1 @@
+usr/lib/syslog-ng/*/libkafka.so

--- a/debian/syslog-ng-mod-snmp.install
+++ b/debian/syslog-ng-mod-snmp.install
@@ -1,0 +1,1 @@
+usr/lib/syslog-ng/*/libsnmpdest.so

--- a/debian/syslog-ng-mod-tag-parser.install
+++ b/debian/syslog-ng-mod-tag-parser.install
@@ -1,1 +1,0 @@
-usr/lib/syslog-ng/*/libtags-parser.so


### PR DESCRIPTION
These set of patches build on top of #3, so that PR should go in first (once that is done, this should go down to a lot less patches).

The patches concentrate on a number module related additions, changes. Most notably:

* snmp() destination is added to a syslog-ng-mod-snmp module. I think we should eventually merge this and syslog-ng-mod-snmptrapd-parser (quite possibly the same merger should happen in the actual source code too).

* the http() destination is moved to a separate package. Right now it is in syslog-ng-core, which I think was a mistake.

* the pacct module was in a separate package, but I think it is ok if we put this in core. It shouldn't have any extra dependencies, it just reads the BSD process accounting files after all, support for which is in the libc

* the tags-parser() was again put in a separate package (with a slight typo as the package was called syslog-ng-mod-tag-parser), again this should just go to "core".

* tag kafka-c() destination driver that builds on top of librdkafka, which is put in a separate package called syslog-ng-mod-rdkafka.

I think we should give some thought on how we split modules into core and dedicated mod packages. Sometimes I feel we have too much of them (e.g. tag-parser), in other cases we have too few (e.g. http). With this patch I was trying to mimic the existing policy as I understood it.
