### PR TITLE
Move include directive before default outputs

### DIFF
--- a/debian/syslog-ng.conf
+++ b/debian/syslog-ng.conf
@@ -119,6 +119,11 @@ filter f_ppp { facility(local2) and not filter(f_debug); };
 filter f_console { level(warn .. emerg); };
 
 ########################
+# Include all config files in /etc/syslog-ng/conf.d/
+########################
+@include "/etc/syslog-ng/conf.d/*.conf"
+
+########################
 # Log paths
 ########################
 log { source(s_src); filter(f_auth); destination(d_auth); };
@@ -154,8 +159,3 @@ log { source(s_src); filter(f_crit); destination(d_console); };
 # All messages send to a remote site
 #
 #log { source(s_src); destination(d_net); };
-
-###
-# Include all config files in /etc/syslog-ng/conf.d/
-###
-@include "/etc/syslog-ng/conf.d/*.conf"


### PR DESCRIPTION
This makes it possible to override the default outputs with additional
configuration files without modifying the default syslog-ng.conf
provided by the package.