### PR TITLE
Apply multi-arch hints

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -542,6 +542,7 @@ Depends: syslog-ng-scl, ${misc:Depends}
 Architecture: all
 Priority: optional
 Section: oldlibs
+Multi-Arch: foreign
 Description: transitional package
  This is a transitional package. It can safely be removed.
 


### PR DESCRIPTION
Apply hints suggested by the [multi-arch hinter](https://wiki.debian.org/MultiArch/Hints).

* syslog-ng-mod-extra: Add Multi-Arch: foreign. This fixes: syslog-ng-mod-extra could be marked Multi-Arch: foreign. ([ma-foreign](https://wiki.debian.org/MultiArch/Hints#ma-foreign))

Note that in some cases, these multi-arch hints may trigger lintian warnings until the dependencies of the package support multi-arch. This is expected, see [https://janitor.debian.net/multiarch-fixes#why-does-lintian-warn](the FAQ) for details.

This merge proposal was created by the [Janitor bot](https://janitor.debian.net/multiarch-fixes), and it will automatically rebase or close this proposal as appropriate when the target branch changes. Any comments you leave here will be read by the Janitor's maintainers.

Build and test logs for this branch can be found at https://janitor.debian.net/run/4c3c9095-17fe-4db8-86cb-e45a59bd8094.