### PR TITLE
Fix LSB header delimiter

### DIFF
--- a/debian/syslog-ng-core.syslog-ng.init
+++ b/debian/syslog-ng-core.syslog-ng.init
@@ -8,7 +8,7 @@
 # Short-Description: Starting system logging daemon
 # Description:       Starting syslog-NG, the next generation
 #  syslog daemon.
-### END INIT INFO#
+### END INIT INFO
 
 set -e
 


### PR DESCRIPTION
Remove trailing `#` in LSB delimiter, conforming to https://wiki.debian.org/LSBInitScripts

Thanks!